### PR TITLE
[Cleanup] Move Home screen styling logic to separate file

### DIFF
--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,45 +1,14 @@
-import React, { useCallback, useEffect, useState } from "react";
-import styled from "styled-components/native";
+import React, { useCallback, useEffect } from "react";
 import { FlatList } from "react-native";
 
 import { useStore, useDispatch } from "../../store";
 
-const View = styled.SafeAreaView`
-  background-color: #ffc600;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-`;
+import { Image, View, Background } from './styles';
 
-const Image = styled.Image`
-  width: 100%;
-  height: 300px;
-
-  margin-bottom: 50px;
-`;
-
-export const Background = styled.SafeAreaView`
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: #ffc600;
-`;
-
-export default function App() {
+export default function Home() {
   const { posts, loading } = useStore();
   const dispatch = useDispatch();
   const renderItem = useCallback(({ item }) => <Image source={item.url} />, []);
-
-  const timeout = setTimeout(() => {
-    dispatch.setLoading(false);
-
-    clearTimeout(timeout);
-  }, 5000);
 
   useEffect(() => {
     if (loading) {

--- a/src/screens/Home/styles.ts
+++ b/src/screens/Home/styles.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components/native";
+
+export const View = styled.SafeAreaView`
+  background-color: #ffc600;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+`;
+
+export const Image = styled.Image`
+  width: 100%;
+  height: 300px;
+
+  margin-bottom: 50px;
+`;
+
+export const Background = styled.SafeAreaView`
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #ffc600;
+`;

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -12,10 +12,10 @@ export interface State {
  * @TODO Should I use an enum or should I use a Union Type here?
  */
 enum ActionTypes {
-  SET_LOADING = "SET_LOADING",
-  GET_POSTS_REQUEST = "GET_POSTS_REQUEST",
-  GET_POSTS_SUCCESS = "GET_POSTS_SUCCESS",
-  GET_POSTS_FAILED = "GET_POSTS_FAILED",
+  SET_LOADING = 'SET_LOADING',
+  GET_POSTS_REQUEST = 'GET_POSTS_REQUEST',
+  GET_POSTS_SUCCESS = 'GET_POSTS_SUCCESS',
+  GET_POSTS_FAILED = 'GET_POSTS_FAILED',
 }
 
 export interface Action {
@@ -25,12 +25,13 @@ export interface Action {
 
 export default function reducer(state: State, action: Action) {
   switch (action.type) {
-    case "GET_POSTS_SUCCESS":
+    case 'GET_POSTS_SUCCESS':
       return {
         ...state,
+        loading: false,
         posts: action.payload,
       };
-    case "SET_LOADING":
+    case 'SET_LOADING':
       return {
         ...state,
         isLoading: action.payload,


### PR DESCRIPTION
In this PR we are moving styling specific logic to make the component file a little less cluttered 😊

The idea is to have components follow this folder structure:

```
Component/
  styles.ts
  constants.ts
  utils.ts
  index.tsx  <-- Component Files
``` 
